### PR TITLE
should "require" angular-mocks in teaspoon spec helper

### DIFF
--- a/find_and_browse.md
+++ b/find_and_browse.md
@@ -366,7 +366,7 @@ our test files, and it generated `spec/javascripts/spec_helper.coffee` for us, w
 line to the file:
 
 ```coffeescript
-#= angular-mocks/angular-mocks
+#= require angular-mocks/angular-mocks
 ```
 
 The last step in setting up our front-end testing is to write a basic spec that uses our controller.  The boilerplate for this


### PR DESCRIPTION
Without the 'require', Angular-mocks will not be loaded during tests, and we get this error when running rake teaspoon

```
1) RecipesController encountered a declaration exception
Failure/Error: ReferenceError: Can't find variable: module in http://127.0.0.1:57538/assets/controllers/RecipesController_spec.js?body=1 (line 22)
```

as seen in issue #3 
