### PR TITLE
db:setup will print warning without schema.rb

### DIFF
--- a/bootstrap.md
+++ b/bootstrap.md
@@ -100,7 +100,7 @@ Now, we can install our gems:
 Once this is done, let's set up our database so we can run the app.
 
     > vim config/database.yml # set the user/password for your local database
-    > rake db:setup
+    > bin/rake db:create
     > rails s
 
 Visit http://localhost:3000 to make sure your app is running, then quit the


### PR DESCRIPTION
When no schema.rb is present, which is the case in a new Rails app, using db:setup shows a warning:

```
/Users/joost/Rails/leegstandscan/db/schema.rb doesn't exist yet. Run `rake db:migrate` to create it, then try again. If you do not intend to use a database, you should instead alter /Users/joost/Rails/leegstandscan/config/application.rb to limit the frameworks that will be loaded.
```

using db:create prevents that.